### PR TITLE
Fix nil pointer

### DIFF
--- a/ens.go
+++ b/ens.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
+
 	// log "github.com/sirupsen/logrus"
 	"golang.org/x/net/idna"
 
@@ -179,8 +180,11 @@ func (client *Client) resolve(ethClient *ethclient.Client, nameServiceChain int,
 		return common.Address{}, 0, e
 	}
 	bs, err := ethClient.CallContract(context.Background(), msg, nil)
-	if err != nil || common.Bytes2Hex(bs) == EmptyAddress {
+	if err != nil {
 		return common.Address{}, 0, &ErrorWithHttpCode{http.StatusNotFound, err.Error()}
+	}
+	if common.Bytes2Hex(bs) == EmptyAddress {
+		return common.Address{}, 0, &ErrorWithHttpCode{http.StatusNotFound, "empty address"}
 	}
 	res, e := parseOutput(bs, "address")
 	if e != nil {


### PR DESCRIPTION
Fix error

```
http: panic serving 10.110.0.4:34076: runtime error: invalid memory address or nil pointer dereference
goroutine 21283 [running]:
net/http.(*conn).serve.func1()
        /usr/local/go/src/net/http/server.go:1854 +0xbf
panic({0x961040, 0xd910c0})
        /usr/local/go/src/runtime/panic.go:890 +0x263
github.com/web3-protocol/web3protocol-go.(*Client).resolve(0x0?, 0x0?, 0x0?, {0x22, 0x61, 0x59, 0xd5, 0x92, 0xe2, 0xb0, ...}, ...)
        /root/go/pkg/mod/github.com/web3-protocol/web3protocol-go@v0.2.3/ens.go:183 +0x231
github.com/web3-protocol/web3protocol-go.(*Client).getAddressFromNameServiceWebHandler(0x8?, 0xc0000288a0?, {0xc0004221a7, 0x7})
        /root/go/pkg/mod/github.com/web3-protocol/web3protocol-go@v0.2.3/ens.go:173 +0xad4
github.com/web3-protocol/web3protocol-go.(*Client).ParseUrl(_, {_, _})
        /root/go/pkg/mod/github.com/web3-protocol/web3protocol-go@v0.2.3/protocol.go:261 +0xef5
github.com/web3-protocol/web3protocol-go.(*Client).FetchUrl(0xc00016a244?, {0xc0004221a0, 0x19})
        /root/go/pkg/mod/github.com/web3-protocol/web3protocol-go@v0.2.3/protocol.go:136 +0xd0
main.handle({0xace410, 0xc0000ea540}, 0xc0000c2800)
        /root/gateway/web3url-gateway/cmd/server/protocol.go:64 +0x5aa
net/http.HandlerFunc.ServeHTTP(0xc0000a8f00?, {0xace410?, 0xc0000ea540?}, 0x410be8?)
        /usr/local/go/src/net/http/server.go:2122 +0x2f
net/http.(*ServeMux).ServeHTTP(0x0?, {0xace410, 0xc0000ea540}, 0xc0000c2800)
        /usr/local/go/src/net/http/server.go:2500 +0x149
net/http.serverHandler.ServeHTTP({0xc00010db90?}, {0xace410, 0xc0000ea540}, 0xc0000c2800)
        /usr/local/go/src/net/http/server.go:2936 +0x316
net/http.(*conn).serve(0xc0000253b0, {0xace8d8, 0xc0001519e0})
        /usr/local/go/src/net/http/server.go:1995 +0x612
created by net/http.(*Server).Serve
        /usr/local/go/src/net/http/server.go:3089 +0x5ed
```